### PR TITLE
styling fix to make the widget centered on fullscreen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "quasar-ttf",
       "version": "0.0.1",
-      "hasInstallScript": true,
       "dependencies": {
         "@quasar/extras": "^1.16.4",
         "quasar": "^2.16.0",
@@ -27,9 +26,8 @@
         "vite-plugin-checker": "^0.8.0"
       },
       "engines": {
-        "node": "^28 || ^26 || ^24 || ^22 || ^20 || ^18",
-        "npm": ">= 6.13.4",
-        "yarn": ">= 1.21.1"
+        "node": ">= 12.22.1",
+        "npm": ">= 6.13.4"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/components/TrueToFormDialogLayoutContainer.vue
+++ b/src/components/TrueToFormDialogLayoutContainer.vue
@@ -16,8 +16,8 @@
             <div class="row justify-center" style="padding-top: 10px">
               <div
                 id="TTF_WIDGET_CONTAINER"
-                data-product-id="Ca42eYkVLSEXLdhJhjq2"
-                data-api-key="9522490933534"
+                data-api-key="Ca42eYkVLSEXLdhJhjq2"
+                data-product-id="9522490933534"
               ></div>
             </div>
           </div>

--- a/src/components/TrueToFormDialogLayoutContainer.vue
+++ b/src/components/TrueToFormDialogLayoutContainer.vue
@@ -3,39 +3,42 @@
     :model-value="modelValue"
     @update:model-value="$emit('update:modelValue', $event)"
     @before-show="InitializeWidget"
+    :maximized="true"
   >
     <q-layout ref="TabRef" container class="bg-lm-lightest">
-      <q-card>
-        <q-card-section>
-          <div class="text-h6">TTF Example TH134 Modal</div>
-        </q-card-section>
+      <div class="flex justify-center items-center h-full">
+        <q-card>
+          <q-card-section>
+            <div class="text-h6">TTF Example TH134 Modal</div>
+          </q-card-section>
 
-        <q-card-section>
-          <div style="background-color: red; color: white">TTF_WIDGET_CONTAINER</div>
-          <div style="border: solid 1px red; height: 40px">
-            <div class="row justify-center" style="padding-top: 10px">
-              <div
-                id="TTF_WIDGET_CONTAINER"
-                data-api-key="Ca42eYkVLSEXLdhJhjq2"
-                data-product-id="9522490933534"
-              ></div>
+          <q-card-section>
+            <div style="background-color: red; color: white">TTF_WIDGET_CONTAINER</div>
+            <div style="border: solid 1px red; height: 40px">
+              <div class="row justify-center" style="padding-top: 10px">
+                <div
+                  id="TTF_WIDGET_CONTAINER"
+                  data-api-key="Ca42eYkVLSEXLdhJhjq2"
+                  data-product-id="9522490933534"
+                ></div>
+              </div>
             </div>
-          </div>
-        </q-card-section>
+          </q-card-section>
 
-        <q-card-section>
-          <div
-            style="min-width: 500px; text-align: center; padding: 30px 0; background-color: #eee"
-          >
-            EXISTING TH134 CHOOSE SIZE STUFF
-          </div>
-        </q-card-section>
+          <q-card-section>
+            <div
+              style="min-width: 500px; text-align: center; padding: 30px 0; background-color: #eee"
+            >
+              EXISTING TH134 CHOOSE SIZE STUFF
+            </div>
+          </q-card-section>
 
-        <q-card-actions align="right">
-          <q-btn flat label="Unload TTF Script" @click="UnloadWidgetScript()" />
-          <q-btn flat label="Close" color="primary" v-close-popup />
-        </q-card-actions>
-      </q-card>
+          <q-card-actions align="right">
+            <q-btn flat label="Unload TTF Script" @click="UnloadWidgetScript()" />
+            <q-btn flat label="Close" color="primary" v-close-popup />
+          </q-card-actions>
+        </q-card>
+      </div>
     </q-layout>
   </q-dialog>
 </template>

--- a/src/components/TrueToFormDialogLayoutContainer.vue
+++ b/src/components/TrueToFormDialogLayoutContainer.vue
@@ -1,96 +1,100 @@
-
-    
 <template>
   <q-dialog
     :model-value="modelValue"
     @update:model-value="$emit('update:modelValue', $event)"
     @before-show="InitializeWidget"
   >
-  <q-layout ref="TabRef" container class="bg-lm-lightest">
-    <q-card>
-      <q-card-section>
-        <div class="text-h6">TTF Example TH134 Modal</div>
-      </q-card-section>
+    <q-layout ref="TabRef" container class="bg-lm-lightest">
+      <q-card>
+        <q-card-section>
+          <div class="text-h6">TTF Example TH134 Modal</div>
+        </q-card-section>
 
-      <q-card-section>
-        <div style="background-color: red; color: white">
-          TTF_WIDGET_CONTAINER
-        </div>
-        <div style="border: solid 1px red; height: 40px;"> 
-          <div class="row justify-center" style="padding-top: 10px;">
+        <q-card-section>
+          <div style="background-color: red; color: white">TTF_WIDGET_CONTAINER</div>
+          <div style="border: solid 1px red; height: 40px">
+            <div class="row justify-center" style="padding-top: 10px">
+              <div
+                id="TTF_WIDGET_CONTAINER"
+                data-product-id="Ca42eYkVLSEXLdhJhjq2"
+                data-api-key="9522490933534"
+              ></div>
+            </div>
+          </div>
+        </q-card-section>
+
+        <q-card-section>
           <div
-              id="TTF_WIDGET_CONTAINER"
-              data-product-id="TH134"
-              data-api-key="i8ZWxd3vHEgf8vczXE5N"
-          ></div>
-        </div>
-        </div>
-      </q-card-section>
+            style="min-width: 500px; text-align: center; padding: 30px 0; background-color: #eee"
+          >
+            EXISTING TH134 CHOOSE SIZE STUFF
+          </div>
+        </q-card-section>
 
-      <q-card-section>
-        <div style="min-width: 500px; text-align: center; padding: 30px 0; background-color: #eee;">EXISTING TH134 CHOOSE SIZE STUFF</div>
-      </q-card-section>
-
-      <q-card-actions align="right">
-        <q-btn flat label="Unload TTF Script" @click="UnloadWidgetScript()" />
-        <q-btn flat label="Close" color="primary" v-close-popup />
-      </q-card-actions>
-    </q-card>
+        <q-card-actions align="right">
+          <q-btn flat label="Unload TTF Script" @click="UnloadWidgetScript()" />
+          <q-btn flat label="Close" color="primary" v-close-popup />
+        </q-card-actions>
+      </q-card>
     </q-layout>
   </q-dialog>
 </template>
 
 <script>
 export default {
-    name: 'TrueToForm',
-    mounted () {
-        this.LoadWidgetScript()
+  name: 'TrueToForm',
+  mounted() {
+    this.LoadWidgetScript()
+  },
+  methods: {
+    UnloadWidgetScript() {
+      document.querySelector('script[data-script-source="ttf-widget"]').remove()
     },
-    methods: {
-      UnloadWidgetScript () {
-        document.querySelector('script[data-script-source="ttf-widget"]').remove()
-      },
-        LoadWidgetScript () {
-                // Check if the script is already loaded
-                if (document.querySelector('script[src="https://ttf-widget.pages.dev/assets/integrations/custom.js"]')) {
-                    this.InitializeWidget()
-                    return
-                }
+    LoadWidgetScript() {
+      // Check if the script is already loaded
+      if (
+        document.querySelector(
+          'script[src="https://ttf-widget.pages.dev/assets/integrations/custom.js"]',
+        )
+      ) {
+        this.InitializeWidget()
+        return
+      }
 
-                // Dynamically create a script tag and load the external JS file
-                const script = document.createElement('script')
-                script.type = 'module'
-                script.src = 'https://ttf-widget.pages.dev/assets/integrations/custom.js'
-                script.setAttribute('data-script-source', 'ttf-widget')
+      // Dynamically create a script tag and load the external JS file
+      const script = document.createElement('script')
+      script.type = 'module'
+      script.src = 'https://ttf-widget.pages.dev/assets/integrations/custom.js'
+      script.setAttribute('data-script-source', 'ttf-widget')
 
-                // Once the script is loaded, initialize the widget
-                script.onload = () => {
-                    this.InitializeWidget()
-                }
+      // Once the script is loaded, initialize the widget
+      script.onload = () => {
+        this.InitializeWidget()
+      }
 
-                // Append the script to the document body
-                document.body.appendChild(script)
-            },
-            InitializeWidget () {
-                const container = document.querySelector('#TTF_WIDGET_CONTAINER')
+      // Append the script to the document body
+      document.body.appendChild(script)
+    },
+    InitializeWidget() {
+      const container = document.querySelector('#TTF_WIDGET_CONTAINER')
 
-                if (!container) {
-                    console.error('TTF Widget container not found.')
-                    return
-                }
+      if (!container) {
+        console.error('TTF Widget container not found.')
+        return
+      }
 
-                const apiKey = container.getAttribute('data-api-key')
-                const productId = container.getAttribute('data-product-id')
+      const apiKey = container.getAttribute('data-api-key')
+      const productId = container.getAttribute('data-product-id')
 
-                if (!apiKey || !productId) {
-                    console.error('Missing API key or Product ID.')
-                    // return
-                }
+      if (!apiKey || !productId) {
+        console.error('Missing API key or Product ID.')
+        // return
+      }
 
-            // Call the widget's initialization logic here if necessary
-            // This depends on what the external JS provides
-            // console.log("TTF Widget initialized with API Key:", apiKey, "and Product ID:", productId)
-            }
-    }
+      // Call the widget's initialization logic here if necessary
+      // This depends on what the external JS provides
+      // console.log("TTF Widget initialized with API Key:", apiKey, "and Product ID:", productId)
+    },
+  },
 }
 </script>

--- a/src/components/TrueToFormDialogLayoutContainer.vue
+++ b/src/components/TrueToFormDialogLayoutContainer.vue
@@ -57,7 +57,7 @@ export default {
       // Check if the script is already loaded
       if (
         document.querySelector(
-          'script[src="https://ttf-widget.pages.dev/assets/integrations/custom.js"]',
+          'script[src="https://dev-ttf-widget.pages.dev/assets/integrations/custom.js"]',
         )
       ) {
         this.InitializeWidget()

--- a/src/components/TrueToFormDialogLayoutNoContainer.vue
+++ b/src/components/TrueToFormDialogLayoutNoContainer.vue
@@ -16,8 +16,8 @@
             <div class="row justify-center" style="padding-top: 10px">
               <div
                 id="TTF_WIDGET_CONTAINER"
-                data-product-id="Ca42eYkVLSEXLdhJhjq2"
-                data-api-key="9522490933534"
+                data-api-key="Ca42eYkVLSEXLdhJhjq2"
+                data-product-id="9522490933534"
               ></div>
             </div>
           </div>

--- a/src/components/TrueToFormDialogLayoutNoContainer.vue
+++ b/src/components/TrueToFormDialogLayoutNoContainer.vue
@@ -1,96 +1,100 @@
-
-    
 <template>
   <q-dialog
     :model-value="modelValue"
     @update:model-value="$emit('update:modelValue', $event)"
     @before-show="InitializeWidget"
   >
-  <q-layout ref="TabRef" class="bg-lm-lightest">
-    <q-card>
-      <q-card-section>
-        <div class="text-h6">TTF Example TH134 Modal</div>
-      </q-card-section>
+    <q-layout ref="TabRef" class="bg-lm-lightest">
+      <q-card>
+        <q-card-section>
+          <div class="text-h6">TTF Example TH134 Modal</div>
+        </q-card-section>
 
-      <q-card-section>
-        <div style="background-color: red; color: white">
-          TTF_WIDGET_CONTAINER
-        </div>
-        <div style="border: solid 1px red; height: 40px;"> 
-          <div class="row justify-center" style="padding-top: 10px;">
+        <q-card-section>
+          <div style="background-color: red; color: white">TTF_WIDGET_CONTAINER</div>
+          <div style="border: solid 1px red; height: 40px">
+            <div class="row justify-center" style="padding-top: 10px">
+              <div
+                id="TTF_WIDGET_CONTAINER"
+                data-product-id="Ca42eYkVLSEXLdhJhjq2"
+                data-api-key="9522490933534"
+              ></div>
+            </div>
+          </div>
+        </q-card-section>
+
+        <q-card-section>
           <div
-              id="TTF_WIDGET_CONTAINER"
-              data-product-id="TH134"
-              data-api-key="i8ZWxd3vHEgf8vczXE5N"
-          ></div>
-        </div>
-        </div>
-      </q-card-section>
+            style="min-width: 500px; text-align: center; padding: 30px 0; background-color: #eee"
+          >
+            EXISTING TH134 CHOOSE SIZE STUFF
+          </div>
+        </q-card-section>
 
-      <q-card-section>
-        <div style="min-width: 500px; text-align: center; padding: 30px 0; background-color: #eee;">EXISTING TH134 CHOOSE SIZE STUFF</div>
-      </q-card-section>
-
-      <q-card-actions align="right">
-        <q-btn flat label="Unload TTF Script" @click="UnloadWidgetScript()" />
-        <q-btn flat label="Close" color="primary" v-close-popup />
-      </q-card-actions>
-    </q-card>
+        <q-card-actions align="right">
+          <q-btn flat label="Unload TTF Script" @click="UnloadWidgetScript()" />
+          <q-btn flat label="Close" color="primary" v-close-popup />
+        </q-card-actions>
+      </q-card>
     </q-layout>
   </q-dialog>
 </template>
 
 <script>
 export default {
-    name: 'TrueToForm',
-    mounted () {
-        this.LoadWidgetScript()
+  name: 'TrueToForm',
+  mounted() {
+    this.LoadWidgetScript()
+  },
+  methods: {
+    UnloadWidgetScript() {
+      document.querySelector('script[data-script-source="ttf-widget"]').remove()
     },
-    methods: {
-      UnloadWidgetScript () {
-        document.querySelector('script[data-script-source="ttf-widget"]').remove()
-      },
-        LoadWidgetScript () {
-                // Check if the script is already loaded
-                if (document.querySelector('script[src="https://ttf-widget.pages.dev/assets/integrations/custom.js"]')) {
-                    this.InitializeWidget()
-                    return
-                }
+    LoadWidgetScript() {
+      // Check if the script is already loaded
+      if (
+        document.querySelector(
+          'script[src="https://ttf-widget.pages.dev/assets/integrations/custom.js"]',
+        )
+      ) {
+        this.InitializeWidget()
+        return
+      }
 
-                // Dynamically create a script tag and load the external JS file
-                const script = document.createElement('script')
-                script.type = 'module'
-                script.src = 'https://ttf-widget.pages.dev/assets/integrations/custom.js'
-                script.setAttribute('data-script-source', 'ttf-widget')
+      // Dynamically create a script tag and load the external JS file
+      const script = document.createElement('script')
+      script.type = 'module'
+      script.src = 'https://ttf-widget.pages.dev/assets/integrations/custom.js'
+      script.setAttribute('data-script-source', 'ttf-widget')
 
-                // Once the script is loaded, initialize the widget
-                script.onload = () => {
-                    this.InitializeWidget()
-                }
+      // Once the script is loaded, initialize the widget
+      script.onload = () => {
+        this.InitializeWidget()
+      }
 
-                // Append the script to the document body
-                document.body.appendChild(script)
-            },
-            InitializeWidget () {
-                const container = document.querySelector('#TTF_WIDGET_CONTAINER')
+      // Append the script to the document body
+      document.body.appendChild(script)
+    },
+    InitializeWidget() {
+      const container = document.querySelector('#TTF_WIDGET_CONTAINER')
 
-                if (!container) {
-                    console.error('TTF Widget container not found.')
-                    return
-                }
+      if (!container) {
+        console.error('TTF Widget container not found.')
+        return
+      }
 
-                const apiKey = container.getAttribute('data-api-key')
-                const productId = container.getAttribute('data-product-id')
+      const apiKey = container.getAttribute('data-api-key')
+      const productId = container.getAttribute('data-product-id')
 
-                if (!apiKey || !productId) {
-                    console.error('Missing API key or Product ID.')
-                    // return
-                }
+      if (!apiKey || !productId) {
+        console.error('Missing API key or Product ID.')
+        // return
+      }
 
-            // Call the widget's initialization logic here if necessary
-            // This depends on what the external JS provides
-            // console.log("TTF Widget initialized with API Key:", apiKey, "and Product ID:", productId)
-            }
-    }
+      // Call the widget's initialization logic here if necessary
+      // This depends on what the external JS provides
+      // console.log("TTF Widget initialized with API Key:", apiKey, "and Product ID:", productId)
+    },
+  },
 }
 </script>

--- a/src/components/TrueToFormDialogLayoutNoContainer.vue
+++ b/src/components/TrueToFormDialogLayoutNoContainer.vue
@@ -54,7 +54,7 @@ export default {
       // Check if the script is already loaded
       if (
         document.querySelector(
-          'script[src="https://ttf-widget.pages.dev/assets/integrations/custom.js"]',
+          'script[src="https://dev-ttf-widget.pages.dev/assets/integrations/custom.js"]',
         )
       ) {
         this.InitializeWidget()

--- a/src/components/TrueToFormDialogNoLayout.vue
+++ b/src/components/TrueToFormDialogNoLayout.vue
@@ -15,8 +15,8 @@
           <div class="row justify-center" style="padding-top: 10px">
             <div
               id="TTF_WIDGET_CONTAINER"
-              data-product-id="Ca42eYkVLSEXLdhJhjq2"
-              data-api-key="9522490933534"
+              data-api-key="Ca42eYkVLSEXLdhJhjq2"
+              data-product-id="9522490933534"
             ></div>
           </div>
         </div>

--- a/src/components/TrueToFormDialogNoLayout.vue
+++ b/src/components/TrueToFormDialogNoLayout.vue
@@ -1,5 +1,3 @@
-
-    
 <template>
   <q-dialog
     :model-value="modelValue"
@@ -12,22 +10,22 @@
       </q-card-section>
 
       <q-card-section>
-        <div style="background-color: red; color: white">
-          TTF_WIDGET_CONTAINER
-        </div>
-        <div style="border: solid 1px red; height: 40px;"> 
-          <div class="row justify-center" style="padding-top: 10px;">
-          <div
+        <div style="background-color: red; color: white">TTF_WIDGET_CONTAINER</div>
+        <div style="border: solid 1px red; height: 40px">
+          <div class="row justify-center" style="padding-top: 10px">
+            <div
               id="TTF_WIDGET_CONTAINER"
-              data-product-id="TH134"
-              data-api-key="i8ZWxd3vHEgf8vczXE5N"
-          ></div>
-        </div>
+              data-product-id="Ca42eYkVLSEXLdhJhjq2"
+              data-api-key="9522490933534"
+            ></div>
+          </div>
         </div>
       </q-card-section>
 
       <q-card-section>
-        <div style="min-width: 500px; text-align: center; padding: 30px 0; background-color: #eee;">EXISTING TH134 CHOOSE SIZE STUFF</div>
+        <div style="min-width: 500px; text-align: center; padding: 30px 0; background-color: #eee">
+          EXISTING TH134 CHOOSE SIZE STUFF
+        </div>
       </q-card-section>
 
       <q-card-actions align="right">
@@ -40,55 +38,59 @@
 
 <script>
 export default {
-    name: 'TrueToForm',
-    mounted () {
-        this.LoadWidgetScript()
+  name: 'TrueToForm',
+  mounted() {
+    this.LoadWidgetScript()
+  },
+  methods: {
+    UnloadWidgetScript() {
+      document.querySelector('script[data-script-source="ttf-widget"]').remove()
     },
-    methods: {
-      UnloadWidgetScript () {
-        document.querySelector('script[data-script-source="ttf-widget"]').remove()
-      },
-        LoadWidgetScript () {
-                // Check if the script is already loaded
-                if (document.querySelector('script[src="https://ttf-widget.pages.dev/assets/integrations/custom.js"]')) {
-                    this.InitializeWidget()
-                    return
-                }
+    LoadWidgetScript() {
+      // Check if the script is already loaded
+      if (
+        document.querySelector(
+          'script[src="https://ttf-widget.pages.dev/assets/integrations/custom.js"]',
+        )
+      ) {
+        this.InitializeWidget()
+        return
+      }
 
-                // Dynamically create a script tag and load the external JS file
-                const script = document.createElement('script')
-                script.type = 'module'
-                script.src = 'https://ttf-widget.pages.dev/assets/integrations/custom.js'
-                script.setAttribute('data-script-source', 'ttf-widget')
+      // Dynamically create a script tag and load the external JS file
+      const script = document.createElement('script')
+      script.type = 'module'
+      script.src = 'https://ttf-widget.pages.dev/assets/integrations/custom.js'
+      script.setAttribute('data-script-source', 'ttf-widget')
 
-                // Once the script is loaded, initialize the widget
-                script.onload = () => {
-                    this.InitializeWidget()
-                }
+      // Once the script is loaded, initialize the widget
+      script.onload = () => {
+        this.InitializeWidget()
+      }
 
-                // Append the script to the document body
-                document.body.appendChild(script)
-            },
-            InitializeWidget () {
-                const container = document.querySelector('#TTF_WIDGET_CONTAINER')
+      // Append the script to the document body
+      document.body.appendChild(script)
+    },
+    InitializeWidget() {
+      const container = document.querySelector('#TTF_WIDGET_CONTAINER')
 
-                if (!container) {
-                    console.error('TTF Widget container not found.')
-                    return
-                }
+      if (!container) {
+        console.error('TTF Widget container not found.')
+        return
+      }
 
-                const apiKey = container.getAttribute('data-api-key')
-                const productId = container.getAttribute('data-product-id')
+      const apiKey = container.getAttribute('data-api-key')
+      const productId = container.getAttribute('data-product-id')
 
-                if (!apiKey || !productId) {
-                    console.error('Missing API key or Product ID.')
-                    // return
-                }
+      if (!apiKey || !productId) {
+        console.error('Missing API key or Product ID.')
+        // return
+      }
 
-            // Call the widget's initialization logic here if necessary
-            // This depends on what the external JS provides
-            // console.log("TTF Widget initialized with API Key:", apiKey, "and Product ID:", productId)
-            }
-    }
+      // Call the widget's initialization logic here if necessary
+      // This depends on what the external JS provides
+      // console.log("TTF Widget initialized with API Key:", apiKey, "and Product ID:", productId)
+    },
+  },
 }
 </script>

--- a/src/components/TrueToFormDialogNoLayout.vue
+++ b/src/components/TrueToFormDialogNoLayout.vue
@@ -50,7 +50,7 @@ export default {
       // Check if the script is already loaded
       if (
         document.querySelector(
-          'script[src="https://ttf-widget.pages.dev/assets/integrations/custom.js"]',
+          'script[src="https://dev-ttf-widget.pages.dev/assets/integrations/custom.js"]',
         )
       ) {
         this.InitializeWidget()


### PR DESCRIPTION
Hi,

please test this locally because only the localhost:9100 is whitelisted. the widget here is using our dev API so if you tried to add any products id from your store it won't work. 

other than adding the creds for the dev widget I edited the styles for the LayoutContainer component so that it takes the fullscreen dimensions because the widget will use the coords of your modal since it's mounted on a Portal. it still also uses the portal coords but because it's now using the full width/height it works the same as on other modals. 
it either doing it this way or not using protal/container on your modal. 

the remaining issues are still the widget not cleaning up when unmounts I will try to add a fix form the widget first and if it worked it should be reflected here without doing any updates. but I will notify you with another PR. 

Note:
sorry about the formatting changes :smile:

Thanks,
Mostafa 